### PR TITLE
Add guest mode functionality (1/3)

### DIFF
--- a/include/hardware/bluetooth.h
+++ b/include/hardware/bluetooth.h
@@ -486,7 +486,7 @@ typedef struct {
     int (*initq)(bt_callbacks_t* callbacks);
 
     /** Enable Bluetooth. */
-    int (*enable)(void);
+    int (*enable)(bool guest_mode);
 
     /** Disable Bluetooth. */
     int (*disable)(void);


### PR DESCRIPTION
Add a flag to enable() to start Bluetooth in restricted
mode. In restricted mode, all devices that are paired during
restricted mode are deleted upon leaving restricted mode.
Right now restricted mode is only entered while a guest
user is active

CYNGNOS-3020
Bug: 27410683
Change-Id: I994a2933fd60301927ff2df65da634f81d4c9428
(cherry picked from commit 4e10135ef499073711944860ccf9a7c43b8bf6ac)
